### PR TITLE
[D] Allow square-bracket access for snake_case properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     "brace-style": [2, "1tbs", {"allowSingleLine": true}],
     "comma-style": [2, "last"],
     "computed-property-spacing": [2, "never"],
+    "dot-notation": [2, {"allowPattern": "^[a-z]+(_[a-z]+)+$"}],
     "indent": [2, 2],
     "linebreak-style": [2, "unix"],
     "no-multiple-empty-lines": [2, {"max": 1}],


### PR DESCRIPTION
This will allow to use square-bracket notation for accessing object properties named with snake_case.

```
const params = {}
params['some_key'] = 'query'
# instead of
params.some_key = 'query'
```