### PR TITLE
Disable no-invalid-this rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
     // Best Practices
     "dot-location": [2, "property"],
     "no-implicit-coercion": [2, {"boolean": true}],
-    "no-invalid-this": 2,
+    "no-invalid-this": 0,
     "no-self-compare": 2,
     "radix": 2,
     "wrap-iife": 2,


### PR DESCRIPTION
Arguments:

- It’s common approach (eg in beforeEach)
- Some 3rd-part API’s rely on this (eg CasperJS)

Before: will throw an error
After: will be valid

``` js
beforeEach(function() {
  this.clock = sinon.useFakeTimers()
})
```