### PR TITLE
Enforce spaces inside of curly braces in objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
     "no-nested-ternary": 2,
     "no-underscore-dangle": 0,
     "no-unneeded-ternary": 2,
-    "object-curly-spacing": [2, "never"],
+    "object-curly-spacing": [2, "always"],
     "operator-assignment": [2, "always"],
     "operator-linebreak": [2, "after"],
     "padded-blocks": [2, "never"],


### PR DESCRIPTION
Pros:

- Most popular appoach (see Airbnb JavaScript Style Guide)
- Consistent with `() => { qwe }`
- Makes difference between `{ qwe }` (object shortcut) and \`${qwe}\`
  more prominent

Cons:

- Not consistent with common approach to arrays: `[1, 2, 3]`
- Highly subjective

Before:

``` js
import {foo} from 'bar'
var {x} = y
var obj = {baz: {foo: 'qux'}, bar}
```

After

``` js
import { foo } from 'bar'
var { x } = y
var obj = { baz: { foo: 'qux' }, bar }
```