### PR TITLE
Disable radix rule since it's not relevant anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     "no-implicit-coercion": [2, {"boolean": true}],
     "no-invalid-this": 2,
     "no-self-compare": 2,
-    "radix": 2,
+    "radix": 0,
     "wrap-iife": 2,
     // Stylistic Issues
     "array-bracket-spacing": [2, "never"],


### PR DESCRIPTION
Nowadays, `parseInt('071')` will not return `57` as you might assume, this "best practice" is not relevant anymore:

<img width="279" alt="developer_tools_-_http___eslint_org_docs_rules_radix_and_1__tmux___users_koss_src_toptal_eslint-config-toptal__tmux_" src="https://cloud.githubusercontent.com/assets/52201/9271002/37653d5a-42b1-11e5-95c0-114a73621491.png">

Before:

``` js
parseInt(abc, 10)
```

After:

``` js
parseInt(abc)
```