### PR TITLE
Deprecate custom ESLint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ESLint Config
 
+**Warning! ESLint config is deprecated in favor of [JavaScript Standard Style](http://standardjs.com/)**.
+
 Install `eslint-config-toptal` package:
 
 ```shell


### PR DESCRIPTION
Deprecate our custom ESLint config in favor of [JavaScript Standard Style](http://standardjs.com/).
